### PR TITLE
Update achievements-engine integration for 1.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ export default function App() {
 ## Common Pitfalls
 
 - Hooks must be inside the `AchievementProvider` tree.
-- Use `unlockedIds`, `unlockedAchievements`, and `allAchievements`; `unlocked` is a deprecated v3 alias.
+- Use `unlockedIds`, `unlockedAchievements`, and `allAchievements`; `unlocked` is a deprecated v3 alias planned for removal in 5.0.
 - Do not manually map unlocked IDs into badge objects for the default UI; `AchievementsWidget` reads context.
 - For Next.js App Router or SSR, ensure components using hooks are client components (`"use client"`).
 - For React Native, use `achievements-engine` or `react-achievements/headless` with custom native UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Engine Dependency**: Updated `achievements-engine` peer and dev dependency to `^1.2.0`.
 - **Snapshot-Backed State**: `AchievementProvider` and `useAchievementState` now read canonical achievement state from the engine snapshot API.
 - **Simple Increment**: `useSimpleAchievements().increment()` now delegates to the engine's numeric increment helper.
-- **Compatibility Notices**: Deprecated v3 wrapper and alias guidance now points to a future major release.
+- **Compatibility Notices**: Deprecated v3 wrapper and alias guidance now identifies 5.0 as the planned removal release.
 
 ### Fixed
 - **Async Storage Hydration**: Provider state now waits for engine readiness so IndexedDB, REST, and custom async storage hydrate before the UI settles.
@@ -77,9 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Compatibility Storybook Group**: Deprecated v3 UI wrappers now live under `Compatibility/*` stories so new examples point to the v4 widget/list/modal API
 
 ### Deprecated
-- `useBuiltInUI` is now a no-op and will be removed in 4.2
-- `BadgesButton`, `BadgesModal`, `BadgesButtonWithModal`, and `ConfettiWrapper` remain as compatibility wrappers and will be removed in 4.2
-- `useSimpleAchievements().unlocked` and `useSimpleAchievements().all` remain as v3 aliases and will be removed in 4.2
+- `useBuiltInUI` is now a no-op and will be removed in 5.0
+- `BadgesButton`, `BadgesModal`, `BadgesButtonWithModal`, and `ConfettiWrapper` remain as compatibility wrappers and will be removed in 5.0
+- `useSimpleAchievements().unlocked` and `useSimpleAchievements().all` remain as v3 aliases and will be removed in 5.0
 
 ### Removed
 - Legacy dynamic detection for `react-toastify`, `react-modal`, `react-confetti`, and `react-use`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-05-12
+
+### Added
+- **Engine Snapshot Types**: Re-exported `AchievementSnapshot` and `AchievementUpdateResult` from the root and headless entry points.
+
+### Changed
+- **Engine Dependency**: Updated `achievements-engine` peer and dev dependency to `^1.2.0`.
+- **Snapshot-Backed State**: `AchievementProvider` and `useAchievementState` now read canonical achievement state from the engine snapshot API.
+- **Simple Increment**: `useSimpleAchievements().increment()` now delegates to the engine's numeric increment helper.
+- **Compatibility Notices**: Deprecated v3 wrapper and alias guidance now points to a future major release.
+
+### Fixed
+- **Async Storage Hydration**: Provider state now waits for engine readiness so IndexedDB, REST, and custom async storage hydrate before the UI settles.
+
+---
+
 ## [4.1.1] - 2026-05-11
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-Deprecated aliases from v3, including `unlocked`, remain available until a future major release.
+Deprecated aliases from v3, including `unlocked` and `all`, remain available until 5.0.
 
 ## Event-Based Tracking
 
@@ -239,7 +239,7 @@ React Native UI components are not included in the web package; use `achievement
 - `AchievementsWidget` replaces the legacy manual `BadgesButtonWithModal` setup.
 - `useSimpleAchievements()` now returns `unlockedIds`, `unlockedAchievements`, and `allAchievements`.
 - External UI peer dependencies are no longer required.
-- Deprecated v3 component names remain as compatibility wrappers until a future major release.
+- Deprecated v3 component names remain as compatibility wrappers until 5.0.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-Deprecated aliases from v3, including `unlocked`, remain available until `4.2`.
+Deprecated aliases from v3, including `unlocked`, remain available until a future major release.
 
 ## Event-Based Tracking
 
@@ -239,7 +239,7 @@ React Native UI components are not included in the web package; use `achievement
 - `AchievementsWidget` replaces the legacy manual `BadgesButtonWithModal` setup.
 - `useSimpleAchievements()` now returns `unlockedIds`, `unlockedAchievements`, and `allAchievements`.
 - External UI peer dependencies are no longer required.
-- Deprecated v3 component names remain as compatibility wrappers until `4.2`.
+- Deprecated v3 component names remain as compatibility wrappers until a future major release.
 
 ## License
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -174,7 +174,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-`unlocked` remains as a deprecated v3 alias for `unlockedIds` until a future major release.
+`unlocked` remains as a deprecated v3 alias for `unlockedIds` until 5.0.
 
 ## Event-Based Alternative
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -174,7 +174,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-`unlocked` remains as a deprecated v3 alias for `unlockedIds` until 4.2.
+`unlocked` remains as a deprecated v3 alias for `unlockedIds` until a future major release.
 
 ## Event-Based Alternative
 

--- a/docs/guides/direct-updates.md
+++ b/docs/guides/direct-updates.md
@@ -119,7 +119,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-`unlocked` and `all` are deprecated v3 aliases and will be removed in 4.2.
+`unlocked` and `all` are deprecated v3 aliases and will be removed in a future major release.
 
 ## Custom Placement
 

--- a/docs/guides/direct-updates.md
+++ b/docs/guides/direct-updates.md
@@ -119,7 +119,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-`unlocked` and `all` are deprecated v3 aliases and will be removed in a future major release.
+`unlocked` and `all` are deprecated v3 aliases and will be removed in 5.0.
 
 ## Custom Placement
 

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -116,4 +116,4 @@ Use compact density and modal controls when a themed modal should be denser or l
 
 ## Migration Note
 
-`useBuiltInUI` is no longer needed. It remains accepted as a deprecated no-op until a future major release.
+`useBuiltInUI` is no longer needed. It remains accepted as a deprecated no-op until 5.0.

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -116,4 +116,4 @@ Use compact density and modal controls when a themed modal should be denser or l
 
 ## Migration Note
 
-`useBuiltInUI` is no longer needed. It remains accepted as a deprecated no-op until 4.2.
+`useBuiltInUI` is no longer needed. It remains accepted as a deprecated no-op until a future major release.

--- a/docs/guides/v3-to-v4-migration.md
+++ b/docs/guides/v3-to-v4-migration.md
@@ -59,7 +59,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-The v3 `unlocked` alias still returns IDs, but it is deprecated and will be removed in 4.2.
+The v3 `unlocked` alias still returns IDs, but it is deprecated and will be removed in a future major release.
 
 ### Remove useBuiltInUI
 
@@ -73,7 +73,7 @@ Built-in UI is now the default.
 <AchievementProvider achievements={achievements}>
 ```
 
-`useBuiltInUI` is accepted as a no-op until 4.2.
+`useBuiltInUI` is accepted as a no-op until a future major release.
 
 ### Update Custom Icons
 
@@ -97,7 +97,7 @@ import { AchievementProvider, useAchievementState } from 'react-achievements/hea
 
 The headless entry point does not import DOM UI components and is the recommended base for custom web UI or React Native-specific UI.
 
-## Deprecated Until 4.2
+## Deprecated Compatibility APIs
 
 - `BadgesButton`
 - `BadgesModal`

--- a/docs/guides/v3-to-v4-migration.md
+++ b/docs/guides/v3-to-v4-migration.md
@@ -59,7 +59,7 @@ const {
 } = useSimpleAchievements();
 ```
 
-The v3 `unlocked` alias still returns IDs, but it is deprecated and will be removed in a future major release.
+The v3 `unlocked` alias still returns IDs, but it is deprecated and will be removed in 5.0.
 
 ### Remove useBuiltInUI
 
@@ -73,7 +73,7 @@ Built-in UI is now the default.
 <AchievementProvider achievements={achievements}>
 ```
 
-`useBuiltInUI` is accepted as a no-op until a future major release.
+`useBuiltInUI` is accepted as a no-op until 5.0.
 
 ### Update Custom Icons
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-achievements",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-achievements",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@babel/core": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-achievements",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-achievements",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@babel/core": "^7.22.5",
@@ -33,7 +33,7 @@
         "@types/react": "^18.2.12",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
         "@typescript-eslint/parser": "^8.50.0",
-        "achievements-engine": "^1.1.2",
+        "achievements-engine": "^1.2.0",
         "eslint": "^9.39.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -59,7 +59,7 @@
         "url": "https://github.com/sponsors/dave-b-b"
       },
       "peerDependencies": {
-        "achievements-engine": "^1.1.2",
+        "achievements-engine": "^1.2.0",
         "react": ">=16.8.0"
       }
     },
@@ -5561,9 +5561,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/achievements-engine": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/achievements-engine/-/achievements-engine-1.1.2.tgz",
-      "integrity": "sha512-THWQrKrg5N7WufYYvUPccYcsZgNlf+qB0369ct/HvIu1fPs/RMGdviHL5qS2063PlkWKPg7EdJqCF/ms9+CcxQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/achievements-engine/-/achievements-engine-1.2.0.tgz",
+      "integrity": "sha512-HYvaBEk2klZ754MtHI4qyzeBXgnalczxAtFJHnrbFbwL2jzRSDRlBB9AVPvrA4HYC8Moyd29qU4PujZypxaPGw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-achievements",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Drop-in achievement and gamification system for React applications",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,10 @@
     "ship": "gh workflow run release.yml"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "achievements-engine": "^1.1.2"
+    "achievements-engine": "^1.2.0",
+    "react": ">=16.8.0"
   },
   "devDependencies": {
-    "achievements-engine": "^1.1.2",
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
@@ -67,6 +66,7 @@
     "@types/react": "^18.2.12",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
+    "achievements-engine": "^1.2.0",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/__tests__/achievement.state.test.tsx
+++ b/src/__tests__/achievement.state.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { 
   AchievementProvider, 
   useAchievements,
+  useAchievementState,
   AchievementConfiguration 
 } from '../index';
 import '@testing-library/jest-dom';
@@ -30,6 +31,34 @@ class MockStorage {
   }
   
   clear() {
+    this.metrics = {};
+    this.unlocked = [];
+  }
+}
+
+class MockAsyncStorage {
+  constructor(
+    private metrics: Record<string, any> = {},
+    private unlocked: string[] = []
+  ) {}
+
+  async getMetrics() {
+    return this.metrics;
+  }
+
+  async setMetrics(metrics: Record<string, any>) {
+    this.metrics = { ...metrics };
+  }
+
+  async getUnlockedAchievements() {
+    return [...this.unlocked];
+  }
+
+  async setUnlockedAchievements(achievements: string[]) {
+    this.unlocked = [...achievements];
+  }
+
+  async clear() {
     this.metrics = {};
     this.unlocked = [];
   }
@@ -81,6 +110,18 @@ describe('Achievement State Management', () => {
         <button onClick={() => update({ score: 100, kills: 5 })}>Update State</button>
         <button onClick={reset}>Reset State</button>
         <div data-testid="state-display"></div>
+      </div>
+    );
+  };
+
+  const SnapshotDisplay = () => {
+    const { metrics, unlockedIds, unlockedCount } = useAchievementState();
+
+    return (
+      <div>
+        <div data-testid="snapshot-metrics">{JSON.stringify(metrics)}</div>
+        <div data-testid="snapshot-unlocked">{unlockedIds.join(',')}</div>
+        <div data-testid="snapshot-count">{unlockedCount}</div>
       </div>
     );
   };
@@ -195,4 +236,24 @@ describe('Achievement State Management', () => {
     expect(checkUnlockedContains('score_100')).toBe(true);
     expect(checkUnlockedContains('kills_5')).toBe(true);
   });
-}); 
+
+  it('should hydrate provider state from async storage readiness', async () => {
+    const asyncStorage = new MockAsyncStorage({ score: [100] }, ['score_100']);
+
+    render(
+      <AchievementProvider
+        achievements={achievementConfig}
+        storage={asyncStorage}
+      >
+        <SnapshotDisplay />
+      </AchievementProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-count')).toHaveTextContent('1');
+    });
+
+    expect(screen.getByTestId('snapshot-metrics')).toHaveTextContent('{"score":[100]}');
+    expect(screen.getByTestId('snapshot-unlocked')).toHaveTextContent('score_100');
+  });
+});

--- a/src/core/components/BadgesButton.tsx
+++ b/src/core/components/BadgesButton.tsx
@@ -49,7 +49,7 @@ const getPositionStyles = (
 
 /**
  * @deprecated Use `AchievementsWidget` for new integrations. This v3
- * compatibility wrapper will be removed in 4.2.
+ * compatibility wrapper will be removed in a future major release.
  */
 export const BadgesButton: React.FC<BadgesButtonProps> = ({
     onClick,
@@ -61,7 +61,7 @@ export const BadgesButton: React.FC<BadgesButtonProps> = ({
 }) => {
     React.useEffect(() => {
         warnDeprecation(
-            '`BadgesButton` is deprecated. Use `AchievementsWidget` instead. `BadgesButton` will be removed in 4.2.'
+            '`BadgesButton` is deprecated. Use `AchievementsWidget` instead. `BadgesButton` will be removed in a future major release.'
         );
     }, []);
 

--- a/src/core/components/BadgesButton.tsx
+++ b/src/core/components/BadgesButton.tsx
@@ -49,7 +49,7 @@ const getPositionStyles = (
 
 /**
  * @deprecated Use `AchievementsWidget` for new integrations. This v3
- * compatibility wrapper will be removed in a future major release.
+ * compatibility wrapper will be removed in 5.0.
  */
 export const BadgesButton: React.FC<BadgesButtonProps> = ({
     onClick,
@@ -61,7 +61,7 @@ export const BadgesButton: React.FC<BadgesButtonProps> = ({
 }) => {
     React.useEffect(() => {
         warnDeprecation(
-            '`BadgesButton` is deprecated. Use `AchievementsWidget` instead. `BadgesButton` will be removed in a future major release.'
+            '`BadgesButton` is deprecated. Use `AchievementsWidget` instead. `BadgesButton` will be removed in 5.0.'
         );
     }, []);
 

--- a/src/core/components/BadgesButtonWithModal.tsx
+++ b/src/core/components/BadgesButtonWithModal.tsx
@@ -25,7 +25,7 @@ export interface BadgesButtonWithModalProps {
 
 /**
  * @deprecated Use `AchievementsWidget` for new integrations. This v3
- * compatibility wrapper will be removed in a future major release.
+ * compatibility wrapper will be removed in 5.0.
  */
 export const BadgesButtonWithModal: React.FC<BadgesButtonWithModalProps> = ({
     unlockedAchievements,

--- a/src/core/components/BadgesButtonWithModal.tsx
+++ b/src/core/components/BadgesButtonWithModal.tsx
@@ -25,7 +25,7 @@ export interface BadgesButtonWithModalProps {
 
 /**
  * @deprecated Use `AchievementsWidget` for new integrations. This v3
- * compatibility wrapper will be removed in 4.2.
+ * compatibility wrapper will be removed in a future major release.
  */
 export const BadgesButtonWithModal: React.FC<BadgesButtonWithModalProps> = ({
     unlockedAchievements,

--- a/src/core/components/BadgesModal.tsx
+++ b/src/core/components/BadgesModal.tsx
@@ -17,7 +17,7 @@ export interface BadgesModalProps {
 /**
  * @deprecated Use `AchievementsModal`, `AchievementsWidget`, or
  * `AchievementsList` for new integrations. This v3 compatibility wrapper will
- * be removed in a future major release.
+ * be removed in 5.0.
  */
 export const BadgesModal: React.FC<BadgesModalProps> = ({
   isOpen,
@@ -31,7 +31,7 @@ export const BadgesModal: React.FC<BadgesModalProps> = ({
 }) => {
   useEffect(() => {
     warnDeprecation(
-      '`BadgesModal` is deprecated. Use `AchievementsWidget` or `AchievementsList` instead. `BadgesModal` will be removed in a future major release.'
+      '`BadgesModal` is deprecated. Use `AchievementsWidget` or `AchievementsList` instead. `BadgesModal` will be removed in 5.0.'
     );
   }, []);
 

--- a/src/core/components/BadgesModal.tsx
+++ b/src/core/components/BadgesModal.tsx
@@ -17,7 +17,7 @@ export interface BadgesModalProps {
 /**
  * @deprecated Use `AchievementsModal`, `AchievementsWidget`, or
  * `AchievementsList` for new integrations. This v3 compatibility wrapper will
- * be removed in 4.2.
+ * be removed in a future major release.
  */
 export const BadgesModal: React.FC<BadgesModalProps> = ({
   isOpen,
@@ -31,7 +31,7 @@ export const BadgesModal: React.FC<BadgesModalProps> = ({
 }) => {
   useEffect(() => {
     warnDeprecation(
-      '`BadgesModal` is deprecated. Use `AchievementsWidget` or `AchievementsList` instead. `BadgesModal` will be removed in 4.2.'
+      '`BadgesModal` is deprecated. Use `AchievementsWidget` or `AchievementsList` instead. `BadgesModal` will be removed in a future major release.'
     );
   }, []);
 

--- a/src/core/components/ConfettiWrapper.tsx
+++ b/src/core/components/ConfettiWrapper.tsx
@@ -8,12 +8,12 @@ export interface ConfettiWrapperProps {
 
 /**
  * @deprecated Use the provider `ui.ConfettiComponent` option or the built-in
- * confetti default. This v3 compatibility wrapper will be removed in 4.2.
+ * confetti default. This v3 compatibility wrapper will be removed in a future major release.
  */
 export const ConfettiWrapper: React.FC<ConfettiWrapperProps> = ({ show }) => {
   useEffect(() => {
     warnDeprecation(
-      '`ConfettiWrapper` is deprecated. Use the provider `ui.ConfettiComponent` option or built-in confetti defaults instead. `ConfettiWrapper` will be removed in 4.2.'
+      '`ConfettiWrapper` is deprecated. Use the provider `ui.ConfettiComponent` option or built-in confetti defaults instead. `ConfettiWrapper` will be removed in a future major release.'
     );
   }, []);
 

--- a/src/core/components/ConfettiWrapper.tsx
+++ b/src/core/components/ConfettiWrapper.tsx
@@ -8,12 +8,12 @@ export interface ConfettiWrapperProps {
 
 /**
  * @deprecated Use the provider `ui.ConfettiComponent` option or the built-in
- * confetti default. This v3 compatibility wrapper will be removed in a future major release.
+ * confetti default. This v3 compatibility wrapper will be removed in 5.0.
  */
 export const ConfettiWrapper: React.FC<ConfettiWrapperProps> = ({ show }) => {
   useEffect(() => {
     warnDeprecation(
-      '`ConfettiWrapper` is deprecated. Use the provider `ui.ConfettiComponent` option or built-in confetti defaults instead. `ConfettiWrapper` will be removed in a future major release.'
+      '`ConfettiWrapper` is deprecated. Use the provider `ui.ConfettiComponent` option or built-in confetti defaults instead. `ConfettiWrapper` will be removed in 5.0.'
     );
   }, []);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -89,7 +89,7 @@ export function isAsyncStorage(storage: AnyAchievementStorage): storage is Async
 }
 
 /**
- * @deprecated This type is outdated and will be removed in 4.2.
+ * @deprecated This type is outdated and will be removed in a future major release.
  * Use AchievementContextType from 'react-achievements' instead.
  *
  * This legacy interface does not include the 'engine' property.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -89,7 +89,7 @@ export function isAsyncStorage(storage: AnyAchievementStorage): storage is Async
 }
 
 /**
- * @deprecated This type is outdated and will be removed in a future major release.
+ * @deprecated This type is outdated and will be removed in 5.0.
  * Use AchievementContextType from 'react-achievements' instead.
  *
  * This legacy interface does not include the 'engine' property.

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -63,6 +63,8 @@ export type {
   ExportedData,
   AwardDetails,
   AchievementEngineApi,
+  AchievementSnapshot,
+  AchievementUpdateResult,
   EngineConfig,
   EngineEvent,
   AchievementUnlockedEvent,

--- a/src/hooks/useAchievementState.ts
+++ b/src/hooks/useAchievementState.ts
@@ -1,20 +1,13 @@
 import { useAchievements } from './useAchievements';
 
 export const useAchievementState = () => {
-  const { achievements, getAllAchievements, getState } = useAchievements();
-  const allAchievements = getAllAchievements();
-  const unlockedIds = achievements.unlocked;
-  const unlockedAchievementSet = new Set(unlockedIds);
-  const unlockedAchievements = allAchievements.filter((achievement) =>
-    unlockedAchievementSet.has(achievement.achievementId)
-  );
-
+  const { snapshot } = useAchievements();
   return {
-    unlockedIds,
-    unlockedAchievements,
-    allAchievements,
-    unlockedCount: unlockedIds.length,
-    totalCount: allAchievements.length,
-    metrics: getState().metrics,
+    unlockedIds: snapshot.unlockedIds,
+    unlockedAchievements: snapshot.unlockedAchievements,
+    allAchievements: snapshot.allAchievements,
+    unlockedCount: snapshot.unlockedCount,
+    totalCount: snapshot.totalCount,
+    metrics: snapshot.metrics,
   };
 };

--- a/src/hooks/useSimpleAchievements.ts
+++ b/src/hooks/useSimpleAchievements.ts
@@ -33,11 +33,11 @@ export const useSimpleAchievements = () => {
     importData,
     getAllAchievements: () => achievementState.allAchievements,
     /**
-     * @deprecated Use `unlockedIds` instead. This alias will be removed in 4.2.
+     * @deprecated Use `unlockedIds` instead. This alias will be removed in a future major release.
      */
     unlocked: achievementState.unlockedIds,
     /**
-     * @deprecated Use `allAchievements` instead. This alias will be removed in 4.2.
+     * @deprecated Use `allAchievements` instead. This alias will be removed in a future major release.
      */
     all: achievementState.allAchievements,
   };

--- a/src/hooks/useSimpleAchievements.ts
+++ b/src/hooks/useSimpleAchievements.ts
@@ -33,11 +33,11 @@ export const useSimpleAchievements = () => {
     importData,
     getAllAchievements: () => achievementState.allAchievements,
     /**
-     * @deprecated Use `unlockedIds` instead. This alias will be removed in a future major release.
+     * @deprecated Use `unlockedIds` instead. This alias will be removed in 5.0.
      */
     unlocked: achievementState.unlockedIds,
     /**
-     * @deprecated Use `allAchievements` instead. This alias will be removed in a future major release.
+     * @deprecated Use `allAchievements` instead. This alias will be removed in 5.0.
      */
     all: achievementState.allAchievements,
   };

--- a/src/hooks/useSimpleAchievements.ts
+++ b/src/hooks/useSimpleAchievements.ts
@@ -6,19 +6,13 @@ import { useAchievementState } from './useAchievementState';
  * Provides the v4 happy path for direct metric updates plus explicit state names.
  */
 export const useSimpleAchievements = () => {
-  const { update, reset, getState, exportData, importData } = useAchievements();
+  const { update, reset, getState, exportData, importData, engine } = useAchievements();
   const achievementState = useAchievementState();
 
   const track = (metric: string, value: any) => update({ [metric]: value });
 
   const increment = (metric: string, amount: number = 1) => {
-    const currentState = getState();
-    const currentMetricArray = currentState.metrics[metric] || [0];
-    const currentValue = Array.isArray(currentMetricArray)
-      ? currentMetricArray[0]
-      : currentMetricArray;
-    const newValue = (typeof currentValue === 'number' ? currentValue : 0) + amount;
-    update({ [metric]: newValue });
+    return engine.increment(metric, amount);
   };
 
   const trackMultiple = (metrics: Record<string, any>) => update(metrics);

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,11 @@ export { useWindowSize } from './core/hooks/useWindowSize';
 
 // Framework-agnostic achievement engine
 export {AchievementEngine} from 'achievements-engine';
-export type { AchievementEngineApi } from 'achievements-engine';
+export type {
+    AchievementEngineApi,
+    AchievementSnapshot,
+    AchievementUpdateResult,
+} from 'achievements-engine';
 
 // Re-export engine types for convenience
 export type {

--- a/src/providers/AchievementProvider.tsx
+++ b/src/providers/AchievementProvider.tsx
@@ -34,7 +34,7 @@ export interface AchievementContextType {
   icons: Record<string, string>;
   /**
    * @deprecated Use provider props or the presence of an injected engine directly.
-   * This compatibility flag will be removed in a future major release.
+   * This compatibility flag will be removed in 5.0.
    */
   _isLegacyPattern: boolean;
 }
@@ -52,7 +52,7 @@ export interface AchievementProviderProps {
   onError?: (error: AchievementError) => void;
   /**
    * @deprecated Built-in UI is the default in the web provider. This prop is a
-   * no-op and will be removed in a future major release.
+   * no-op and will be removed in 5.0.
    */
   useBuiltInUI?: boolean;
 }
@@ -78,7 +78,7 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
 }) => {
   if (useBuiltInUI !== undefined) {
     warnDeprecation(
-      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in a future major release.'
+      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in 5.0.'
     );
   }
 

--- a/src/providers/AchievementProvider.tsx
+++ b/src/providers/AchievementProvider.tsx
@@ -5,10 +5,12 @@ import type {
   AchievementStorage,
   AsyncAchievementStorage,
   StorageType,
+  AchievementSnapshot,
   AchievementWithStatus,
   EventMapping,
   ImportOptions,
   ImportResult,
+  StateChangedEvent,
   RestApiStorageConfig,
 } from 'achievements-engine';
 import { warnDeprecation } from '../core/utils/deprecation';
@@ -19,6 +21,7 @@ export interface AchievementContextType {
     unlocked: string[];
     all: Record<string, AchievementWithStatus>;
   };
+  snapshot: AchievementSnapshot;
   reset: () => void;
   getState: () => {
     metrics: Record<string, any>;
@@ -55,13 +58,10 @@ export interface AchievementProviderProps {
 }
 
 const getAllAchievementRecord = (
-  engine: AchievementEngine
+  achievements: AchievementWithStatus[]
 ): Record<string, AchievementWithStatus> => {
   return Object.fromEntries(
-    engine.getAllAchievements().map((achievement) => [
-      achievement.achievementId,
-      achievement,
-    ])
+    achievements.map((achievement) => [achievement.achievementId, achievement])
   );
 };
 
@@ -115,19 +115,12 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
     });
   });
 
-  const [achievementState, setAchievementState] = useState<{
-    unlocked: string[];
-    all: Record<string, AchievementWithStatus>;
-  }>(() => ({
-    unlocked: [...engine.getUnlocked()],
-    all: getAllAchievementRecord(engine),
-  }));
+  const [achievementSnapshot, setAchievementSnapshot] = useState<AchievementSnapshot>(() =>
+    engine.getSnapshot()
+  );
 
-  const syncAchievementState = useCallback(() => {
-    setAchievementState({
-      unlocked: [...engine.getUnlocked()],
-      all: getAllAchievementRecord(engine),
-    });
+  const syncAchievementState = useCallback((snapshot?: AchievementSnapshot) => {
+    setAchievementSnapshot(snapshot || engine.getSnapshot());
   }, [engine]);
 
   useEffect(() => {
@@ -139,11 +132,19 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
   }, [engine, externalEngine]);
 
   useEffect(() => {
-    const unsubscribeUnlocked = engine.on('achievement:unlocked', syncAchievementState);
-    const unsubscribeStateChanged = engine.on('state:changed', syncAchievementState);
+    let isMounted = true;
+    const unsubscribeStateChanged = engine.on('state:changed', (event: StateChangedEvent) => {
+      syncAchievementState(event);
+    });
+
+    engine.ready().then(() => {
+      if (isMounted) {
+        syncAchievementState();
+      }
+    });
 
     return () => {
-      unsubscribeUnlocked();
+      isMounted = false;
       unsubscribeStateChanged();
     };
   }, [engine, syncAchievementState]);
@@ -154,21 +155,14 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
 
   const reset = () => {
     engine.reset();
-    syncAchievementState();
   };
 
   const getState = () => {
-    const metrics = engine.getMetrics();
-    const unlocked = engine.getUnlocked();
-    const metricsInArrayFormat: Record<string, any> = {};
-
-    Object.entries(metrics).forEach(([key, value]) => {
-      metricsInArrayFormat[key] = Array.isArray(value) ? value : [value];
-    });
+    const snapshot = engine.getSnapshot();
 
     return {
-      metrics: metricsInArrayFormat,
-      unlocked: [...unlocked],
+      metrics: snapshot.metrics,
+      unlocked: snapshot.unlockedIds,
     };
   };
 
@@ -183,14 +177,20 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
   };
 
   const getAllAchievements = (): AchievementWithStatus[] => {
-    return engine.getAllAchievements();
+    return engine.getSnapshot().allAchievements;
+  };
+
+  const achievements = {
+    unlocked: achievementSnapshot.unlockedIds,
+    all: getAllAchievementRecord(achievementSnapshot.allAchievements),
   };
 
   return (
     <AchievementContext.Provider
       value={{
         update,
-        achievements: achievementState,
+        achievements,
+        snapshot: achievementSnapshot,
         reset,
         getState,
         exportData,

--- a/src/providers/AchievementProvider.tsx
+++ b/src/providers/AchievementProvider.tsx
@@ -34,7 +34,7 @@ export interface AchievementContextType {
   icons: Record<string, string>;
   /**
    * @deprecated Use provider props or the presence of an injected engine directly.
-   * This compatibility flag will be removed in 4.2.
+   * This compatibility flag will be removed in a future major release.
    */
   _isLegacyPattern: boolean;
 }
@@ -52,7 +52,7 @@ export interface AchievementProviderProps {
   onError?: (error: AchievementError) => void;
   /**
    * @deprecated Built-in UI is the default in the web provider. This prop is a
-   * no-op and will be removed in 4.2.
+   * no-op and will be removed in a future major release.
    */
   useBuiltInUI?: boolean;
 }
@@ -78,7 +78,7 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
 }) => {
   if (useBuiltInUI !== undefined) {
     warnDeprecation(
-      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in 4.2.'
+      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in a future major release.'
     );
   }
 

--- a/src/providers/WebAchievementProvider.tsx
+++ b/src/providers/WebAchievementProvider.tsx
@@ -17,7 +17,7 @@ export interface WebAchievementProviderProps extends HeadlessAchievementProvider
   ui?: UIConfig;
   /**
    * @deprecated Built-in UI is the default in v4. This prop is a no-op and will
-   * be removed in 4.2.
+   * be removed in a future major release.
    */
   useBuiltInUI?: boolean;
 }
@@ -152,7 +152,7 @@ export const AchievementProvider: React.FC<WebAchievementProviderProps> = ({
 }) => {
   if (useBuiltInUI !== undefined) {
     warnDeprecation(
-      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in 4.2.'
+      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in a future major release.'
     );
   }
 

--- a/src/providers/WebAchievementProvider.tsx
+++ b/src/providers/WebAchievementProvider.tsx
@@ -17,7 +17,7 @@ export interface WebAchievementProviderProps extends HeadlessAchievementProvider
   ui?: UIConfig;
   /**
    * @deprecated Built-in UI is the default in v4. This prop is a no-op and will
-   * be removed in a future major release.
+   * be removed in 5.0.
    */
   useBuiltInUI?: boolean;
 }
@@ -152,7 +152,7 @@ export const AchievementProvider: React.FC<WebAchievementProviderProps> = ({
 }) => {
   if (useBuiltInUI !== undefined) {
     warnDeprecation(
-      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in a future major release.'
+      '`useBuiltInUI` is deprecated and is now a no-op because built-in UI is the default. It will be removed in 5.0.'
     );
   }
 


### PR DESCRIPTION
## Summary
- Updates react-achievements to 4.2.0 and achievements-engine to ^1.2.0
- Uses engine snapshots/readiness for provider state and async storage hydration
- Delegates simple increment tracking to the engine and re-exports new engine result types
- Keeps the deprecated v3 compatibility surface available in 4.2.0 while documenting planned removal in 5.0