### PR TITLE
Add configurable canvas confetti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+---
+
+## [4.4.0] - 2026-05-19
+
+### Added
+- **Confetti Customization**: Added `ui.confetti` options for tuning built-in confetti colors, particle count, shapes, spread, velocity, gravity, scale, duration, and z-index.
+- **Per-Reward Confetti**: Added optional reward-level `confetti` settings, including `confetti: false`, so individual achievements can override or skip the global celebration.
+
+### Changed
+- **Built-In Confetti**: Replaced the CSS particle animation with `canvas-confetti` while preserving `enableConfetti`, `ConfettiComponent`, and `BuiltInConfetti` APIs.
+- **Compatibility**: Existing 4.3.0 achievement configs continue to work without adding confetti settings.
+
+---
+
 ## [4.3.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Provider-level icons and UI options are shared across notifications, widgets, mo
   ui={{
     theme: 'minimal',
     notificationDuration: 8000,
+    enableConfetti: true,
+    confetti: {
+      colors: ['#22d3ee', '#f97316', '#facc15'],
+      particleCount: 120,
+      spread: 80,
+    },
     NotificationComponent: MyNotification,
     ModalComponent: MyAchievementsModal,
     ConfettiComponent: MyConfetti,
@@ -134,6 +140,33 @@ Provider-level icons and UI options are shared across notifications, widgets, mo
 >
   <App />
 </AchievementProvider>
+```
+
+Set `ui.enableConfetti` to `false` to disable the built-in celebration. Omit `ConfettiComponent` when you only want to tune the default `canvas-confetti` animation through `ui.confetti`.
+
+Rewards can optionally override the global confetti settings. Omit `confetti` to use the provider defaults, or set `confetti: false` for quieter rewards:
+
+```tsx
+const achievements = {
+  score: {
+    100: {
+      title: 'Century!',
+      description: 'Score 100 points',
+      icon: '🏆',
+    },
+    1000: {
+      title: 'Boss Finale!',
+      description: 'Score 1,000 points',
+      icon: '👑',
+      confetti: {
+        particleCount: 240,
+        spread: 100,
+        startVelocity: 60,
+        scalar: 1.4,
+      },
+    },
+  },
+};
 ```
 
 ## Hooks

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,6 +19,8 @@ npm install react-achievements
 
 React Achievements v4 only requires `react` and `achievements-engine`. The previous optional UI peer dependencies are no longer needed because built-in UI is the default.
 
+Built-in confetti is powered by `canvas-confetti`, which is installed as a package dependency of `react-achievements`; you do not need to install `react-confetti` or `react-canvas-confetti`.
+
 ## Verify Installation
 
 ```tsx title="App.tsx"

--- a/docs/getting-started/v4-feature-setup.md
+++ b/docs/getting-started/v4-feature-setup.md
@@ -45,6 +45,55 @@ Built-in unlock notifications auto-dismiss after 5 seconds by default. Set `ui.n
 </AchievementProvider>
 ```
 
+Tune the built-in `canvas-confetti` celebration through `ui.confetti`:
+
+```tsx
+<AchievementProvider
+  achievements={achievements}
+  ui={{
+    confetti: {
+      colors: ['#22d3ee', '#f97316', '#facc15'],
+      particleCount: 120,
+      spread: 80,
+    },
+  }}
+>
+  <YourApp />
+</AchievementProvider>
+```
+
+Add optional per-reward confetti when one achievement should feel bigger or quieter than the global default. Rewards without `confetti` keep using `ui.confetti` and the selected theme.
+
+```tsx
+const achievements = {
+  score: {
+    100: {
+      title: 'Century!',
+      description: 'Score 100 points',
+    },
+    1000: {
+      title: 'Boss Finale!',
+      description: 'Score 1,000 points',
+      confetti: {
+        colors: ['#facc15', '#f97316', '#ef4444'],
+        particleCount: 240,
+        spread: 100,
+        startVelocity: 60,
+        scalar: 1.4,
+      },
+    },
+  },
+  tutorial: {
+    true: {
+      title: 'Tutorial Complete',
+      confetti: false,
+    },
+  },
+};
+```
+
+`confetti: false` disables confetti only for that reward. `ui.enableConfetti: false` still disables confetti for every reward.
+
 ## 2. Direct Tracking
 
 Use `useSimpleAchievements` for most React apps.
@@ -176,6 +225,8 @@ Replace built-in notification, modal, or confetti components through `ui`.
 Custom `NotificationComponent` implementations receive `duration` and `stackIndex` so they can preserve the same auto-dismiss and stacking behavior as the built-in notifications.
 
 Custom `ModalComponent` implementations receive `hideScrollbar`, `density`, and `backdropBlur` in addition to the base modal props. Honor those props when you want `AchievementsWidget` and `AchievementsModal` controls to work with a provider-level custom modal.
+
+Custom `ConfettiComponent` implementations receive `show` plus the resolved confetti settings for the unlocked reward.
 
 For custom inline rows, use `AchievementsList.renderAchievement`.
 

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -44,6 +44,63 @@ Built-in themes:
 </AchievementProvider>
 ```
 
+## Customize Built-In Confetti
+
+Built-in confetti uses `canvas-confetti`, respects reduced-motion preferences, and can be tuned without replacing the component.
+
+```tsx
+<AchievementProvider
+  achievements={achievements}
+  ui={{
+    confetti: {
+      colors: ['#22d3ee', '#f97316', '#facc15'],
+      particleCount: 120,
+      shapes: ['square', 'circle', 'star'],
+      spread: 80,
+      startVelocity: 45,
+      gravity: 0.9,
+      scalar: 1.1,
+    },
+  }}
+>
+  <App />
+</AchievementProvider>
+```
+
+## Per-Reward Confetti
+
+Rewards inherit the provider confetti settings by default. Add `confetti` only when a reward should celebrate differently, or set `confetti: false` to disable confetti for that reward.
+
+```tsx
+const achievements = {
+  score: {
+    100: {
+      title: 'Century!',
+      description: 'Score 100 points',
+      icon: '🏆',
+    },
+    1000: {
+      title: 'Boss Finale!',
+      description: 'Score 1,000 points',
+      icon: '👑',
+      confetti: {
+        colors: ['#facc15', '#f97316', '#ef4444'],
+        particleCount: 240,
+        spread: 100,
+        startVelocity: 60,
+        scalar: 1.4,
+      },
+    },
+    25: {
+      title: 'Quiet Milestone',
+      confetti: false,
+    },
+  },
+};
+```
+
+Reward settings override matching `ui.confetti` values and inherit anything they omit. Existing configs that do not include `confetti` continue to use the global/theme defaults.
+
 ## Notification Stacking
 
 Built-in unlock notifications auto-dismiss after 5 seconds by default. Use `ui.notificationDuration` to set a different duration in milliseconds. If one update unlocks several achievements, notifications stack in the configured `notificationPosition`.
@@ -72,6 +129,7 @@ Custom `NotificationComponent` implementations receive `duration` and `stackInde
 ```
 
 `ModalComponent` is used by `AchievementsWidget` and `AchievementsModal`. It receives `isOpen`, `onClose`, `achievements`, `icons`, `theme`, `hideScrollbar`, `density`, and `backdropBlur`.
+`ConfettiComponent` receives `show` plus the resolved confetti settings for the unlocked reward.
 
 ## Provider Icons
 

--- a/docs/guides/v3-to-v4-migration.md
+++ b/docs/guides/v3-to-v4-migration.md
@@ -25,6 +25,8 @@ Remove the old optional UI peer dependencies unless your app uses them directly:
 
 The v4 built-in widget and modal are implemented inside `react-achievements`; they do not import `react-modal`.
 
+Built-in confetti is also handled by `react-achievements` through `canvas-confetti`. You can disable it with `ui.enableConfetti: false`, tune the global defaults with `ui.confetti`, or add optional per-reward `confetti` settings. Existing v4 achievement configs that omit `confetti` do not require migration.
+
 ### Use AchievementsWidget
 
 ```tsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "react-achievements",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-achievements",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "canvas-confetti": "^1.9.4"
+      },
       "devDependencies": {
         "@babel/core": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
@@ -29,6 +32,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/jest": "^29.5.2",
         "@types/react": "^18.2.12",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
@@ -4767,6 +4771,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -6424,6 +6435,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-achievements",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Drop-in achievement and gamification system for React applications",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
@@ -62,6 +62,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/jest": "^29.5.2",
     "@types/react": "^18.2.12",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
@@ -109,5 +110,8 @@
   "bugs": {
     "url": "https://github.com/dave-b-b/react-achievements/issues"
   },
-  "homepage": "https://dave-b-b.github.io/react-achievements/"
+  "homepage": "https://dave-b-b.github.io/react-achievements/",
+  "dependencies": {
+    "canvas-confetti": "^1.9.4"
+  }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,7 +10,7 @@ const entries = [
   { name: 'headless', input: 'src/headless.ts' },
 ];
 
-const external = ['react', 'achievements-engine'];
+const external = ['react', 'achievements-engine', 'canvas-confetti'];
 
 const jsBuilds = entries.map(({ name, input }) => ({
   input,

--- a/src/__tests__/core/ui/BuiltInConfetti.test.tsx
+++ b/src/__tests__/core/ui/BuiltInConfetti.test.tsx
@@ -1,47 +1,70 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import confetti from 'canvas-confetti';
 import { BuiltInConfetti } from '../../../core/ui/BuiltInConfetti';
-import * as useWindowSize from '../../../core/hooks/useWindowSize';
 
-// Mock the useWindowSize hook
-jest.mock('../../../core/hooks/useWindowSize', () => ({
-  useWindowSize: jest.fn(),
-}));
+jest.mock('canvas-confetti', () => {
+  const mockConfetti = jest.fn();
+  return {
+    __esModule: true,
+    default: Object.assign(mockConfetti, {
+      reset: jest.fn(),
+    }),
+  };
+});
 
-const useWindowSizeMock = useWindowSize.useWindowSize as jest.Mock;
+const confettiMock = confetti as unknown as jest.Mock & { reset: jest.Mock };
 
 describe('BuiltInConfetti', () => {
   beforeEach(() => {
-    // Provide a default mock implementation for useWindowSize
-    useWindowSizeMock.mockReturnValue({ width: 1024, height: 768 });
     jest.useFakeTimers();
+    confettiMock.mockClear();
+    confettiMock.reset.mockClear();
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
   it('does not render when show is false', () => {
     render(<BuiltInConfetti show={false} />);
     expect(screen.queryByTestId('built-in-confetti')).not.toBeInTheDocument();
+    expect(confettiMock).not.toHaveBeenCalled();
   });
 
-  it('renders when show is true', () => {
+  it('renders and fires canvas confetti when show is true', () => {
     render(<BuiltInConfetti show={true} />);
     expect(screen.getByTestId('built-in-confetti')).toBeInTheDocument();
+    expect(confettiMock).toHaveBeenCalledTimes(3);
   });
 
-  it('renders the correct number of particles', () => {
+  it('uses 80 particles by default', () => {
+    render(<BuiltInConfetti show={true} />);
+
+    const totalParticles = confettiMock.mock.calls.reduce((total, [options]) => {
+      return total + (options?.particleCount || 0);
+    }, 0);
+
+    expect(totalParticles).toBe(80);
+  });
+
+  it('uses particleCount across the burst calls', () => {
     const particleCount = 25;
     render(<BuiltInConfetti show={true} particleCount={particleCount} />);
-    const particles = screen.getAllByTestId('confetti-particle');
-    expect(particles).toHaveLength(particleCount);
+
+    const totalParticles = confettiMock.mock.calls.reduce((total, [options]) => {
+      return total + (options?.particleCount || 0);
+    }, 0);
+
+    expect(totalParticles).toBe(particleCount);
   });
 
   it('disappears after the specified duration', () => {
     const duration = 2000;
-    const { rerender } = render(<BuiltInConfetti show={true} duration={duration} />);
+    render(<BuiltInConfetti show={true} duration={duration} />);
     
     expect(screen.getByTestId('built-in-confetti')).toBeInTheDocument();
 
@@ -49,8 +72,8 @@ describe('BuiltInConfetti', () => {
       jest.advanceTimersByTime(duration);
     });
 
-    rerender(<BuiltInConfetti show={true} duration={duration} />);
     expect(screen.queryByTestId('built-in-confetti')).not.toBeInTheDocument();
+    expect(confettiMock.reset).toHaveBeenCalled();
   });
 
   it('handles multiple show/hide cycles', () => {
@@ -59,20 +82,52 @@ describe('BuiltInConfetti', () => {
 
     rerender(<BuiltInConfetti show={true} />);
     expect(screen.getByTestId('built-in-confetti')).toBeInTheDocument();
+    expect(confettiMock).toHaveBeenCalledTimes(3);
 
     rerender(<BuiltInConfetti show={false} />);
     expect(screen.queryByTestId('built-in-confetti')).not.toBeInTheDocument();
+    expect(confettiMock.reset).toHaveBeenCalled();
   });
 
-  it('uses custom colors for particles', () => {
+  it('passes custom colors to canvas confetti', () => {
     const colors = ['#ff0000', '#00ff00', '#0000ff'];
-    // JSDOM converts hex colors to rgb, so we need to compare against rgb values
-    const expectedRgbColors = ['rgb(255, 0, 0)', 'rgb(0, 255, 0)', 'rgb(0, 0, 255)'];
     render(<BuiltInConfetti show={true} colors={colors} particleCount={30} />);
-    const particles = screen.getAllByTestId('confetti-particle');
-    particles.forEach(particle => {
-      const backgroundColor = particle.style.backgroundColor;
-      expect(expectedRgbColors).toContain(backgroundColor);
+
+    confettiMock.mock.calls.forEach(([options]) => {
+      expect(options?.colors).toEqual(colors);
     });
+  });
+
+  it('passes custom visual options to canvas confetti', () => {
+    render(
+      <BuiltInConfetti
+        show={true}
+        shapes={['star']}
+        spread={90}
+        startVelocity={55}
+        gravity={0.8}
+        scalar={1.2}
+        zIndex={20000}
+      />
+    );
+
+    confettiMock.mock.calls.forEach(([options]) => {
+      expect(options).toEqual(
+        expect.objectContaining({
+          shapes: ['star'],
+          startVelocity: 55,
+          gravity: 0.8,
+          scalar: 1.2,
+          zIndex: 20000,
+          disableForReducedMotion: true,
+        })
+      );
+    });
+
+    expect(confettiMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        spread: 90,
+      })
+    );
   });
 });

--- a/src/__tests__/core/ui/themes.test.ts
+++ b/src/__tests__/core/ui/themes.test.ts
@@ -89,7 +89,7 @@ describe('Theme System', () => {
       expect(theme.notification.textColor).toBe('#22d3ee');
       expect(theme.notification.accentColor).toBe('#f97316');
       expect(theme.modal.achievementLayout).toBe('badge');
-      expect(theme.confetti.particleCount).toBe(100);
+      expect(theme.confetti.particleCount).toBe(120);
     });
 
     it('should have valid color arrays for confetti', () => {

--- a/src/__tests__/providers/AchievementProvider.ui.integration.test.tsx
+++ b/src/__tests__/providers/AchievementProvider.ui.integration.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom';
 import { AchievementProvider } from '../../providers/WebAchievementProvider';
 import { useAchievements } from '../../hooks/useAchievements';
-import { AchievementWithStatus } from '../../core/types';
+import { useSimpleAchievements } from '../../hooks/useSimpleAchievements';
+import { AchievementWithStatus, ConfettiProps } from '../../core/types';
 import { AchievementEngine } from 'achievements-engine';
 
 const mockConfig = {
@@ -24,6 +25,11 @@ const mockConfig = {
 const TestApp = () => {
   const { update } = useAchievements();
   return <button onClick={() => update({ test: 1 })}>Update</button>;
+};
+
+const SimpleScoreApp = () => {
+  const { track } = useSimpleAchievements();
+  return <button onClick={() => track('score', 100)}>Score 100</button>;
 };
 
 describe('AchievementProvider UI Integration', () => {
@@ -155,6 +161,351 @@ describe('AchievementProvider UI Integration', () => {
         });
     });
 
+    it('should pass theme and custom confetti config to ConfettiComponent', async () => {
+        jest.useRealTimers();
+        const CustomConfetti = ({
+            show,
+            colors,
+            duration,
+            particleCount,
+            shapes,
+            spread,
+            startVelocity,
+        }: ConfettiProps) => (
+            show ? (
+                <div
+                    data-testid="custom-confetti"
+                    data-colors={colors?.join(',')}
+                    data-duration={duration}
+                    data-particle-count={particleCount}
+                    data-shapes={shapes?.join(',')}
+                    data-spread={spread}
+                    data-start-velocity={startVelocity}
+                >
+                    Custom Confetti
+                </div>
+            ) : null
+        );
+
+        render(
+            <AchievementProvider
+                achievements={mockConfig.achievements}
+                ui={{
+                    theme: 'minimal',
+                    ConfettiComponent: CustomConfetti,
+                    confetti: {
+                        duration: 3000,
+                        particleCount: 90,
+                        shapes: ['star'],
+                        spread: 85,
+                        startVelocity: 55,
+                    },
+                }}
+                useBuiltInUI={true}
+            >
+                <TestApp />
+            </AchievementProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Update'));
+        });
+
+        await waitFor(() => {
+            const confetti = screen.getByTestId('custom-confetti');
+            expect(confetti).toHaveAttribute('data-colors', '#4CAF50,#2196F3');
+            expect(confetti).toHaveAttribute('data-duration', '3000');
+            expect(confetti).toHaveAttribute('data-particle-count', '90');
+            expect(confetti).toHaveAttribute('data-shapes', 'star');
+            expect(confetti).toHaveAttribute('data-spread', '85');
+            expect(confetti).toHaveAttribute('data-start-velocity', '55');
+        });
+    });
+
+    it('should keep 4.3-style simple configs working without reward confetti', async () => {
+        jest.useRealTimers();
+        render(
+            <AchievementProvider
+                achievements={{
+                    score: {
+                        100: {
+                            title: 'Century',
+                            description: 'Score 100 points',
+                            icon: 'trophy',
+                        },
+                    },
+                }}
+                useBuiltInUI={true}
+            >
+                <SimpleScoreApp />
+            </AchievementProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Score 100'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Century')).toBeInTheDocument();
+            expect(screen.getByTestId('built-in-confetti')).toBeInTheDocument();
+        });
+    });
+
+    it('should use simple reward confetti overrides over global config', async () => {
+        jest.useRealTimers();
+        const CustomConfetti = ({
+            show,
+            colors,
+            duration,
+            particleCount,
+            scalar,
+            spread,
+        }: ConfettiProps) => (
+            show ? (
+                <div
+                    data-testid="custom-confetti"
+                    data-colors={colors?.join(',')}
+                    data-duration={duration}
+                    data-particle-count={particleCount}
+                    data-scalar={scalar}
+                    data-spread={spread}
+                >
+                    Custom Confetti
+                </div>
+            ) : null
+        );
+
+        render(
+            <AchievementProvider
+                achievements={{
+                    score: {
+                        100: {
+                            title: 'Century',
+                            confetti: {
+                                colors: ['#111111', '#222222'],
+                                duration: 7000,
+                                particleCount: 180,
+                                scalar: 1.4,
+                            },
+                        },
+                    },
+                }}
+                ui={{
+                    ConfettiComponent: CustomConfetti,
+                    confetti: {
+                        colors: ['#eeeeee'],
+                        particleCount: 90,
+                        spread: 65,
+                    },
+                }}
+                useBuiltInUI={true}
+            >
+                <SimpleScoreApp />
+            </AchievementProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Score 100'));
+        });
+
+        await waitFor(() => {
+            const confetti = screen.getByTestId('custom-confetti');
+            expect(confetti).toHaveAttribute('data-colors', '#111111,#222222');
+            expect(confetti).toHaveAttribute('data-duration', '7000');
+            expect(confetti).toHaveAttribute('data-particle-count', '180');
+            expect(confetti).toHaveAttribute('data-scalar', '1.4');
+            expect(confetti).toHaveAttribute('data-spread', '65');
+        });
+    });
+
+    it('should keep simple custom-condition reward confetti stable across provider rerenders', async () => {
+        jest.useRealTimers();
+        const CustomConfetti = ({ show, particleCount }: ConfettiProps) => (
+            show ? (
+                <div data-testid="custom-confetti" data-particle-count={particleCount}>
+                    Custom Confetti
+                </div>
+            ) : null
+        );
+        const RerenderingProviderApp = () => {
+            const [renderCount, setRenderCount] = React.useState(0);
+            const achievements = {
+                score: {
+                    boss: {
+                        title: 'Boss Finale',
+                        condition: (metrics: Record<string, unknown>) =>
+                            typeof metrics.score === 'number' && metrics.score >= 100,
+                        confetti: {
+                            particleCount: 210,
+                        },
+                    },
+                },
+            };
+
+            return (
+                <AchievementProvider
+                    achievements={achievements}
+                    ui={{ ConfettiComponent: CustomConfetti }}
+                    useBuiltInUI={true}
+                >
+                    <span data-testid="render-count">{renderCount}</span>
+                    <button onClick={() => setRenderCount((count) => count + 1)}>
+                        Provider Rerender
+                    </button>
+                    <SimpleScoreApp />
+                </AchievementProvider>
+            );
+        };
+
+        render(<RerenderingProviderApp />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Provider Rerender'));
+        });
+
+        expect(screen.getByTestId('render-count')).toHaveTextContent('1');
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Score 100'));
+        });
+
+        await waitFor(() => {
+            const confetti = screen.getByTestId('custom-confetti');
+            expect(confetti).toHaveAttribute('data-particle-count', '210');
+        });
+    });
+
+    it('should use complex reward confetti overrides over global config', async () => {
+        jest.useRealTimers();
+        const CustomConfetti = ({ show, particleCount, spread }: ConfettiProps) => (
+            show ? (
+                <div
+                    data-testid="custom-confetti"
+                    data-particle-count={particleCount}
+                    data-spread={spread}
+                >
+                    Custom Confetti
+                </div>
+            ) : null
+        );
+
+        render(
+            <AchievementProvider
+                achievements={{
+                    test: [
+                        {
+                            achievementDetails: {
+                                achievementId: 'boss-finale',
+                                achievementTitle: 'Boss Finale',
+                                achievementDescription: 'Clear the boss fight',
+                                confetti: {
+                                    particleCount: 240,
+                                },
+                            },
+                            isConditionMet: () => true,
+                        },
+                    ],
+                }}
+                ui={{
+                    ConfettiComponent: CustomConfetti,
+                    confetti: {
+                        particleCount: 90,
+                        spread: 75,
+                    },
+                }}
+                useBuiltInUI={true}
+            >
+                <TestApp />
+            </AchievementProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Update'));
+        });
+
+        await waitFor(() => {
+            const confetti = screen.getByTestId('custom-confetti');
+            expect(confetti).toHaveAttribute('data-particle-count', '240');
+            expect(confetti).toHaveAttribute('data-spread', '75');
+        });
+    });
+
+    it('should skip confetti when a reward sets confetti to false', async () => {
+        jest.useRealTimers();
+        const CustomConfetti = ({ show }: ConfettiProps) => (
+            show ? <div data-testid="custom-confetti">Custom Confetti</div> : null
+        );
+
+        render(
+            <AchievementProvider
+                achievements={{
+                    test: [
+                        {
+                            achievementDetails: {
+                                achievementId: 'quiet-unlock',
+                                achievementTitle: 'Quiet Unlock',
+                                achievementDescription: 'No celebration',
+                                confetti: false,
+                            },
+                            isConditionMet: () => true,
+                        },
+                    ],
+                }}
+                ui={{ ConfettiComponent: CustomConfetti }}
+                useBuiltInUI={true}
+            >
+                <TestApp />
+            </AchievementProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Update'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Quiet Unlock')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('custom-confetti')).not.toBeInTheDocument();
+    });
+
+    it('should let global confetti disable override reward confetti', async () => {
+        jest.useRealTimers();
+        const CustomConfetti = ({ show }: ConfettiProps) => (
+            show ? <div data-testid="custom-confetti">Custom Confetti</div> : null
+        );
+
+        render(
+            <AchievementProvider
+                achievements={{
+                    score: {
+                        100: {
+                            title: 'Century',
+                            confetti: {
+                                particleCount: 180,
+                            },
+                        },
+                    },
+                }}
+                ui={{
+                    ConfettiComponent: CustomConfetti,
+                    enableConfetti: false,
+                }}
+                useBuiltInUI={true}
+            >
+                <SimpleScoreApp />
+            </AchievementProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Score 100'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Century')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('custom-confetti')).not.toBeInTheDocument();
+    });
+
     it('should apply all notification positions correctly', async () => {
         jest.useRealTimers();
         const positions = ['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'] as const;
@@ -280,4 +631,3 @@ describe('AchievementProvider UI with Event-Based Engine', () => {
         }, { timeout: 3000 });
     });
 });
-

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,11 +14,14 @@ export interface AchievementDetails {
     achievementTitle: string;
     achievementDescription: string;
     achievementIconKey?: string;
+    confetti?: AchievementConfetti;
 }
 
 export interface AchievementWithStatus extends AchievementDetails {
     isUnlocked: boolean;
 }
+
+export type AchievementConfetti = false | import('./ui/interfaces').ConfettiOptions;
 
 export type AchievementUIDensity = 'comfortable' | 'compact';
 export type AchievementUIBackdropBlur = number | string;
@@ -37,6 +40,7 @@ export interface SimpleAchievementDetails {
     title: string;
     description?: string;
     icon?: string;
+    confetti?: AchievementConfetti;
 }
 
 export interface CustomAchievementDetails extends SimpleAchievementDetails {
@@ -162,6 +166,8 @@ export type {
     ModalComponent,
     ConfettiProps,
     ConfettiComponent,
+    ConfettiOptions,
+    ConfettiShape,
     NotificationPosition,
     ThemeConfig,
     UIConfig,

--- a/src/core/ui/BuiltInConfetti.tsx
+++ b/src/core/ui/BuiltInConfetti.tsx
@@ -1,87 +1,111 @@
 import React, { useEffect, useState } from 'react';
+import confetti from 'canvas-confetti';
 import { ConfettiProps } from './interfaces';
-import { useWindowSize } from '../hooks/useWindowSize';
+
+const DEFAULT_COLORS = ['#FFD700', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7'];
+const DEFAULT_DURATION_MS = 5000;
+const DEFAULT_PARTICLE_COUNT = 80;
+const DEFAULT_SHAPES: NonNullable<ConfettiProps['shapes']> = ['square', 'circle'];
+const DEFAULT_SPREAD = 70;
+const DEFAULT_START_VELOCITY = 45;
+const DEFAULT_GRAVITY = 1;
+const DEFAULT_SCALAR = 1;
+const DEFAULT_Z_INDEX = 10001;
+
+const getSafeParticleCount = (count: number): number => Math.max(0, Math.floor(count));
 
 /**
  * Built-in confetti component
- * Lightweight CSS-based confetti animation
+ * Canvas-based confetti animation powered by canvas-confetti.
  */
 export const BuiltInConfetti: React.FC<ConfettiProps> = ({
   show,
-  duration = 5000,
-  particleCount = 50,
-  colors = ['#FFD700', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7'],
+  duration = DEFAULT_DURATION_MS,
+  particleCount = DEFAULT_PARTICLE_COUNT,
+  colors = DEFAULT_COLORS,
+  shapes = DEFAULT_SHAPES,
+  spread = DEFAULT_SPREAD,
+  startVelocity = DEFAULT_START_VELOCITY,
+  gravity = DEFAULT_GRAVITY,
+  scalar = DEFAULT_SCALAR,
+  zIndex = DEFAULT_Z_INDEX,
 }) => {
   const [isVisible, setIsVisible] = useState(false);
-  const { width, height } = useWindowSize();
 
   useEffect(() => {
-    if (show) {
-      setIsVisible(true);
-      const timer = setTimeout(() => setIsVisible(false), duration);
-      return () => clearTimeout(timer);
-    } else {
+    if (!show) {
       setIsVisible(false);
+      confetti.reset();
+      return;
     }
-  }, [show, duration]);
+
+    setIsVisible(true);
+
+    const totalParticles = getSafeParticleCount(particleCount);
+    const resolvedColors = colors.length > 0 ? colors : DEFAULT_COLORS;
+    const resolvedShapes = shapes.length > 0 ? shapes : DEFAULT_SHAPES;
+    const baseOptions = {
+      colors: resolvedColors,
+      shapes: resolvedShapes,
+      spread,
+      startVelocity,
+      gravity,
+      scalar,
+      zIndex,
+      disableForReducedMotion: true,
+    };
+
+    if (totalParticles > 0) {
+      const centerParticles = Math.ceil(totalParticles * 0.5);
+      const leftParticles = Math.floor((totalParticles - centerParticles) / 2);
+      const rightParticles = totalParticles - centerParticles - leftParticles;
+
+      confetti({
+        ...baseOptions,
+        particleCount: centerParticles,
+        origin: { x: 0.5, y: 0.58 },
+      });
+
+      confetti({
+        ...baseOptions,
+        particleCount: leftParticles,
+        angle: 60,
+        spread: Math.max(45, spread * 0.8),
+        origin: { x: 0, y: 0.72 },
+      });
+
+      confetti({
+        ...baseOptions,
+        particleCount: rightParticles,
+        angle: 120,
+        spread: Math.max(45, spread * 0.8),
+        origin: { x: 1, y: 0.72 },
+      });
+    }
+
+    const timer = setTimeout(() => {
+      setIsVisible(false);
+      confetti.reset();
+    }, duration);
+
+    return () => {
+      clearTimeout(timer);
+      confetti.reset();
+    };
+  }, [
+    show,
+    duration,
+    particleCount,
+    colors,
+    shapes,
+    spread,
+    startVelocity,
+    gravity,
+    scalar,
+    zIndex,
+  ]);
 
   if (!isVisible) return null;
 
-  const containerStyles: React.CSSProperties = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    pointerEvents: 'none',
-    zIndex: 10001,
-    overflow: 'hidden',
-  };
-
-  // Generate particles
-  const particles = Array.from({ length: particleCount }, (_, i) => {
-    const color = colors[Math.floor(Math.random() * colors.length)];
-    const startX = Math.random() * width;
-    const rotation = Math.random() * 360;
-    const fallDuration = 3 + Math.random() * 2; // 3-5 seconds
-    const delay = Math.random() * 0.5; // 0-0.5s delay
-    const shape = Math.random() > 0.5 ? 'circle' : 'square';
-
-    const particleStyles: React.CSSProperties = {
-      position: 'absolute',
-      top: '-20px',
-      left: `${startX}px`,
-      width: '10px',
-      height: '10px',
-      backgroundColor: color,
-      borderRadius: shape === 'circle' ? '50%' : '0',
-      transform: `rotate(${rotation}deg)`,
-      animation: `confettiFall ${fallDuration}s linear ${delay}s forwards`,
-      opacity: 0.9,
-    };
-
-    return <div key={i} style={particleStyles} data-testid="confetti-particle" />;
-  });
-
-  return (
-    <>
-      <style>
-        {`
-          @keyframes confettiFall {
-            0% {
-              transform: translateY(0) rotate(0deg);
-              opacity: 1;
-            }
-            100% {
-              transform: translateY(${height + 50}px) rotate(720deg);
-              opacity: 0;
-            }
-          }
-        `}
-      </style>
-      <div style={containerStyles} data-testid="built-in-confetti">
-        {particles}
-      </div>
-    </>
-  );
+  return <div data-testid="built-in-confetti" style={{ display: 'none' }} />;
 };

--- a/src/core/ui/interfaces.ts
+++ b/src/core/ui/interfaces.ts
@@ -43,15 +43,30 @@ export interface ModalProps {
 
 export type ModalComponent = React.FC<ModalProps>;
 
+export type ConfettiShape = 'square' | 'circle' | 'star';
+
+export interface ConfettiOptions {
+  /**
+   * Duration in milliseconds before the built-in confetti marker is removed.
+   * Custom confetti components receive this value through `duration`.
+   */
+  duration?: number;
+  particleCount?: number;
+  colors?: string[];
+  shapes?: ConfettiShape[];
+  spread?: number;
+  startVelocity?: number;
+  gravity?: number;
+  scalar?: number;
+  zIndex?: number;
+}
+
 /**
  * Confetti component interface
  * Displays celebration animation
  */
-export interface ConfettiProps {
+export interface ConfettiProps extends ConfettiOptions {
   show: boolean;
-  duration?: number;
-  particleCount?: number;
-  colors?: string[];
 }
 
 export type ConfettiComponent = React.FC<ConfettiProps>;
@@ -95,10 +110,9 @@ export interface ThemeConfig {
     achievementCardBorderRadius?: string; // Optional: for square/badge-like achievement cards
     achievementLayout?: 'horizontal' | 'badge'; // Optional: layout style for achievement cards
   };
-  confetti: {
+  confetti: ConfettiOptions & {
     colors: string[];
     particleCount: number;
-    shapes?: ('circle' | 'square')[];
   };
 }
 
@@ -155,4 +169,10 @@ export interface UIConfig {
    * @default true
    */
   enableConfetti?: boolean;
+
+  /**
+   * Built-in confetti configuration. Ignored when `enableConfetti` is false.
+   * Custom confetti components receive these values as props.
+   */
+  confetti?: ConfettiOptions;
 }

--- a/src/core/ui/themes.ts
+++ b/src/core/ui/themes.ts
@@ -32,7 +32,7 @@ export const builtInThemes: Record<string, ThemeConfig> = {
     },
     confetti: {
       colors: ['#FFD700', '#4CAF50', '#2196F3', '#FF6B6B'],
-      particleCount: 50,
+      particleCount: 80,
       shapes: ['circle', 'square'],
     },
   },
@@ -65,7 +65,7 @@ export const builtInThemes: Record<string, ThemeConfig> = {
     },
     confetti: {
       colors: ['#4CAF50', '#2196F3'],
-      particleCount: 30,
+      particleCount: 40,
       shapes: ['circle'],
     },
   },
@@ -101,7 +101,7 @@ export const builtInThemes: Record<string, ThemeConfig> = {
     },
     confetti: {
       colors: ['#22d3ee', '#f97316', '#a855f7', '#eab308'], // Cyan, orange, purple, yellow
-      particleCount: 100,
+      particleCount: 120,
       shapes: ['circle', 'square'],
     },
   },

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -15,6 +15,7 @@ export type {
   AchievementStorage,
   AsyncAchievementStorage,
   AnyAchievementStorage,
+  AchievementConfetti,
   AchievementContextValue,
 } from './core/types';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type {
     AchievementStorage,
     AsyncAchievementStorage,
     AnyAchievementStorage,
+    AchievementConfetti,
     AchievementContextValue, // @deprecated - use AchievementContextType instead
     StylesProps,
 } from './core/types';
@@ -136,6 +137,8 @@ export type {
     ModalProps,
     ConfettiComponent,
     ConfettiProps,
+    ConfettiOptions,
+    ConfettiShape,
     NotificationPosition,
     ThemeConfig,
     UIConfig,

--- a/src/providers/AchievementProvider.tsx
+++ b/src/providers/AchievementProvider.tsx
@@ -1,18 +1,18 @@
 import React, { createContext, useCallback, useEffect, useState } from 'react';
 import { AchievementEngine, AchievementError } from 'achievements-engine';
 import type {
-  AchievementConfigurationType,
   AchievementStorage,
   AsyncAchievementStorage,
   StorageType,
   AchievementSnapshot,
-  AchievementWithStatus,
   EventMapping,
   ImportOptions,
   ImportResult,
   StateChangedEvent,
   RestApiStorageConfig,
+  AchievementConfigurationType as EngineAchievementConfigurationType,
 } from 'achievements-engine';
+import type { AchievementConfigurationType, AchievementWithStatus } from '../core/types';
 import { warnDeprecation } from '../core/utils/deprecation';
 
 export interface AchievementContextType {
@@ -107,7 +107,7 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({
     }
 
     return new AchievementEngine({
-      achievements: achievementsConfig,
+      achievements: achievementsConfig as EngineAchievementConfigurationType,
       storage: storage as any,
       restApiConfig,
       onError: onError as ((error: Error) => void) | undefined,

--- a/src/providers/WebAchievementProvider.tsx
+++ b/src/providers/WebAchievementProvider.tsx
@@ -1,5 +1,9 @@
 import React, { createContext, useEffect, useMemo, useRef, useState } from 'react';
-import type { AchievementUnlockedEvent, AchievementWithStatus } from 'achievements-engine';
+import { isSimpleConfig, normalizeAchievements } from 'achievements-engine';
+import type {
+  AchievementConfigurationType as EngineAchievementConfigurationType,
+  AchievementUnlockedEvent,
+} from 'achievements-engine';
 import {
   AchievementProvider as HeadlessAchievementProvider,
   AchievementProviderProps as HeadlessAchievementProviderProps,
@@ -7,11 +11,99 @@ import {
 import { useAchievementEngine } from '../hooks/useAchievementEngine';
 import { BuiltInNotification } from '../core/ui/BuiltInNotification';
 import { BuiltInConfetti } from '../core/ui/BuiltInConfetti';
-import type { ConfettiComponent, NotificationComponent, UIConfig } from '../core/types';
+import { builtInThemes, getTheme } from '../core/ui/themes';
+import type {
+  AchievementConfiguration,
+  AchievementConfetti,
+  AchievementWithStatus,
+  ConfettiComponent,
+  ConfettiOptions,
+  NotificationComponent,
+  SimpleAchievementConfig,
+  UIConfig,
+} from '../core/types';
 import { warnDeprecation } from '../core/utils/deprecation';
 
 const DEFAULT_NOTIFICATION_DURATION_MS = 5000;
 const CONFETTI_DURATION_MS = 5000;
+
+type AchievementConfettiMap = Map<string, AchievementConfetti>;
+
+const hasConfiguredConfetti = (
+  confetti: AchievementConfetti | undefined
+): confetti is AchievementConfetti => {
+  return confetti === false || (typeof confetti === 'object' && confetti !== null);
+};
+
+const collectComplexConfetti = (
+  achievements: AchievementConfiguration,
+  confettiByAchievementId: AchievementConfettiMap
+) => {
+  Object.values(achievements).forEach((metricAchievements) => {
+    metricAchievements.forEach(({ achievementDetails }) => {
+      const confetti = achievementDetails.confetti;
+
+      if (hasConfiguredConfetti(confetti)) {
+        confettiByAchievementId.set(achievementDetails.achievementId, confetti);
+      }
+    });
+  });
+};
+
+const simpleConfigHasRewardConfetti = (achievements: SimpleAchievementConfig): boolean => {
+  return Object.values(achievements).some((metricAchievements) =>
+    Object.values(metricAchievements).some((achievement) =>
+      hasConfiguredConfetti(achievement.confetti)
+    )
+  );
+};
+
+const prepareAchievementsForConfetti = (
+  achievements: HeadlessAchievementProviderProps['achievements']
+): {
+  achievements: HeadlessAchievementProviderProps['achievements'];
+  confettiByAchievementId: AchievementConfettiMap;
+} => {
+  const confettiByAchievementId: AchievementConfettiMap = new Map();
+
+  if (!achievements) {
+    return { achievements, confettiByAchievementId };
+  }
+
+  if (!isSimpleConfig(achievements as EngineAchievementConfigurationType)) {
+    collectComplexConfetti(achievements as AchievementConfiguration, confettiByAchievementId);
+    return { achievements, confettiByAchievementId };
+  }
+
+  const simpleAchievements = achievements as SimpleAchievementConfig;
+
+  if (!simpleConfigHasRewardConfetti(simpleAchievements)) {
+    return { achievements, confettiByAchievementId };
+  }
+
+  const normalizedAchievements = normalizeAchievements(
+    simpleAchievements as EngineAchievementConfigurationType
+  ) as AchievementConfiguration;
+
+  Object.entries(simpleAchievements).forEach(([metric, metricAchievements]) => {
+    const normalizedMetricAchievements = normalizedAchievements[metric] || [];
+
+    Object.values(metricAchievements).forEach((achievement, index) => {
+      const confetti = achievement.confetti;
+      const normalizedAchievement = normalizedMetricAchievements[index];
+
+      if (normalizedAchievement && hasConfiguredConfetti(confetti)) {
+        normalizedAchievement.achievementDetails.confetti = confetti;
+        confettiByAchievementId.set(
+          normalizedAchievement.achievementDetails.achievementId,
+          confetti
+        );
+      }
+    });
+  });
+
+  return { achievements: normalizedAchievements, confettiByAchievementId };
+};
 
 export interface WebAchievementProviderProps extends HeadlessAchievementProviderProps {
   icons?: Record<string, string>;
@@ -36,13 +128,49 @@ export const AchievementUIContext = createContext<AchievementUIContextValue>({
 const AchievementEffects: React.FC<{
   icons: Record<string, string>;
   ui: UIConfig;
-}> = ({ icons, ui }) => {
+  achievementConfetti: AchievementConfettiMap;
+}> = ({ icons, ui, achievementConfetti }) => {
   const engine = useAchievementEngine();
   const seenAchievementsRef = useRef<Set<string>>(new Set(engine.getUnlocked()));
   const confettiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const achievementConfettiRef = useRef(achievementConfetti);
   const [showConfetti, setShowConfetti] = useState(false);
+  const [activeConfettiConfig, setActiveConfettiConfig] = useState<ConfettiOptions | null>(null);
   const [notifications, setNotifications] = useState<AchievementWithStatus[]>([]);
   const notificationDuration = ui.notificationDuration ?? DEFAULT_NOTIFICATION_DURATION_MS;
+  const themeName = ui.theme || 'modern';
+  const themeConfig = useMemo(() => getTheme(themeName) || builtInThemes.modern, [themeName]);
+  const globalConfettiConfig = useMemo<ConfettiOptions>(
+    () => ({
+      ...themeConfig.confetti,
+      ...ui.confetti,
+    }),
+    [themeConfig, ui.confetti]
+  );
+  const globalConfettiConfigRef = useRef(globalConfettiConfig);
+  const renderedConfettiConfig =
+    showConfetti && activeConfettiConfig ? activeConfettiConfig : globalConfettiConfig;
+  const renderedConfettiDuration = renderedConfettiConfig.duration ?? CONFETTI_DURATION_MS;
+
+  useEffect(() => {
+    achievementConfettiRef.current = achievementConfetti;
+  }, [achievementConfetti]);
+
+  useEffect(() => {
+    globalConfettiConfigRef.current = globalConfettiConfig;
+  }, [globalConfettiConfig]);
+
+  useEffect(() => {
+    if (ui.enableConfetti === false) {
+      if (confettiTimerRef.current) {
+        clearTimeout(confettiTimerRef.current);
+        confettiTimerRef.current = null;
+      }
+
+      setShowConfetti(false);
+      setActiveConfettiConfig(null);
+    }
+  }, [ui.enableConfetti]);
 
   useEffect(() => {
     const unsubscribeUnlocked = engine.on(
@@ -77,16 +205,26 @@ const AchievementEffects: React.FC<{
           });
         }
 
-        if (ui.enableConfetti !== false) {
+        const rewardConfetti = achievementConfettiRef.current.get(event.achievementId);
+
+        if (ui.enableConfetti !== false && rewardConfetti !== false) {
           if (confettiTimerRef.current) {
             clearTimeout(confettiTimerRef.current);
           }
 
+          const resolvedConfettiConfig: ConfettiOptions = {
+            ...globalConfettiConfigRef.current,
+            ...(rewardConfetti || {}),
+          };
+          const resolvedConfettiDuration =
+            resolvedConfettiConfig.duration ?? CONFETTI_DURATION_MS;
+
+          setActiveConfettiConfig(resolvedConfettiConfig);
           setShowConfetti(true);
           confettiTimerRef.current = setTimeout(() => {
             setShowConfetti(false);
             confettiTimerRef.current = null;
-          }, CONFETTI_DURATION_MS);
+          }, resolvedConfettiDuration);
         }
       }
     );
@@ -139,7 +277,11 @@ const AchievementEffects: React.FC<{
         ))}
 
       {ui.enableConfetti !== false && (
-        <ConfettiComponentResolved show={showConfetti} duration={CONFETTI_DURATION_MS} />
+        <ConfettiComponentResolved
+          show={showConfetti}
+          {...renderedConfettiConfig}
+          duration={renderedConfettiDuration}
+        />
       )}
     </>
   );
@@ -158,13 +300,24 @@ export const AchievementProvider: React.FC<WebAchievementProviderProps> = ({
     );
   }
 
+  const [{ achievements: preparedAchievements, confettiByAchievementId }] = useState(() =>
+    prepareAchievementsForConfetti(providerProps.achievements)
+  );
   const uiContextValue = useMemo(() => ({ icons, ui }), [icons, ui]);
 
   return (
     <AchievementUIContext.Provider value={uiContextValue}>
-      <HeadlessAchievementProvider {...providerProps} icons={icons}>
+      <HeadlessAchievementProvider
+        {...providerProps}
+        achievements={preparedAchievements}
+        icons={icons}
+      >
         {children}
-        <AchievementEffects icons={icons} ui={ui} />
+        <AchievementEffects
+          achievementConfetti={confettiByAchievementId}
+          icons={icons}
+          ui={ui}
+        />
       </HeadlessAchievementProvider>
     </AchievementUIContext.Provider>
   );

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,16 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
+jest.mock('canvas-confetti', () => {
+  const mockConfetti = jest.fn(() => Promise.resolve(undefined));
+  return {
+    __esModule: true,
+    default: Object.assign(mockConfetti, {
+      reset: jest.fn(),
+    }),
+  };
+});
+
 /**
  * Suppress known React act() warnings from component-internal async operations.
  * 
@@ -84,4 +94,4 @@ const localStorageMock = {
   length: 0,
   key: jest.fn(),
 };
-Object.defineProperty(window, 'localStorage', { value: localStorageMock }); 
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });


### PR DESCRIPTION
## Summary
- Replace the built-in CSS confetti effect with canvas-confetti and expose global ui.confetti options
- Add optional per-reward confetti overrides, including confetti: false for quiet rewards
- Preserve existing 4.3.0 configs, bump the package to 4.4.0, and update README/Docusaurus docs

## Tests
- npm test
- npm run build
- npm run lint (0 errors, existing warnings remain)
- cd docs && npm run typecheck
- cd docs && npm run build